### PR TITLE
fix: arrow tips vanish when in 3D

### DIFF
--- a/src/manim_cad_drawing_utils/path_mapper.py
+++ b/src/manim_cad_drawing_utils/path_mapper.py
@@ -177,10 +177,12 @@ class Path_mapper(VMobject):
     def get_tangent_angle(self,s):
         tv = self.get_tangent_unit_vector(s)
         return angle_of_vector(tv)
-
+    
     def get_normal_unit_vector(self,s):
         tv = self.get_tangent_unit_vector(s)
-        return rotate_vector(tv,PI/2)
+        # Tangent and rotation axis must not be collinear
+        axis = Y_AXIS if np.linalg.norm(np.cross(tv, Z_AXIS)) == 0 else Z_AXIS
+        return rotate_vector(tv, PI/2, axis=axis)
 
     def get_curvature_vector(self,s):
         indx, bz_a = self.get_bezier_index_from_length(s)
@@ -389,7 +391,7 @@ class Curve_Warp(VMobject):
         super().__init__(**kwargs)
         self.match_style(warp_source)
 
-    def generate_points(self):
+    def generate_points(self, sketch_plane=None):
 
         s0 = self.PM.length_from_alpha(self.anchor_point)
         x_points = self.warp_source.points[:, 0] + s0

--- a/src/manim_cad_drawing_utils/path_mapper.py
+++ b/src/manim_cad_drawing_utils/path_mapper.py
@@ -178,10 +178,14 @@ class Path_mapper(VMobject):
         tv = self.get_tangent_unit_vector(s)
         return angle_of_vector(tv)
     
+    def are_two_vectors_collinear(self, v1, v2, tolerance=1e-15):
+        return np.linalg.norm(np.cross(v1, v2)) < tolerance
+    
     def get_normal_unit_vector(self,s):
         tv = self.get_tangent_unit_vector(s)
         # Tangent and rotation axis must not be collinear
-        axis = Y_AXIS if np.linalg.norm(np.cross(tv, Z_AXIS)) == 0 else Z_AXIS
+        # @todo They should be orthogonal
+        axis = Y_AXIS if self.are_two_vectors_collinear(tv, Z_AXIS) else Z_AXIS
         return rotate_vector(tv, PI/2, axis=axis)
 
     def get_curvature_vector(self,s):


### PR DESCRIPTION
When I draw vertical dimension in 3D, arrow tips vanish because lack of valid normal vector. This pull request is a fix for this behavior. Example is presented below.

```python
class TestScene(ThreeDScene):
    def construct(self):
        
        self.set_camera_orientation(phi=60*DEGREES, theta=45*DEGREES, zoom=1)
        
        line = Line(IN, OUT)
        
        dimH = Linear_Dimension(line.get_critical_point(OUT),
                                line.get_critical_point(IN),
                                direction=RIGHT,
                                offset=1.5,
                                outside_arrow=True)
        
        self.add(line, dimH)
        self.wait()
```